### PR TITLE
Strict types for filter option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,17 +16,21 @@ export default class CssoWebpackPlugin {
         this.options = options;
         this.filter = filter;
 
-        if (isFilterType(this.options) && typeof this.filter === 'undefined') {
+        if (isFilterType(options) && filter === undefined) {
             this.filter = options;
             this.options = undefined;
         }
 
-        if (typeof this.filter === 'undefined') {
+        if (this.filter === undefined) {
             this.filter = filterDefault;
         }
 
+        if (this.filter instanceof RegExp) {
+            this.filter = createRegexpFilter(this.filter);
+        }
+
         if (typeof this.filter !== 'function') {
-            this.filter = createRegexpFilter(filter);
+            throw new Error('filter should be one of these types: function, regexp, undefined');
         }
 
         this.options = this.options || {

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+const CssoWebpackPlugin = require('../lib').default;
+
+describe('Constructor', function() {
+    function testDefaultOptions(plugin) {
+        assert.deepEqual(plugin.options, {sourceMap: false}, 'default options inited');
+    }
+
+    function testDefaultFilter(plugin) {
+        assert.equal(plugin.filter('files.css'), true, 'files.css should be true');
+        assert.equal(plugin.filter('files.js'), false, 'files.js should be false');
+        assert.equal(plugin.filter('/.css/file'), false, '/.css/file should be false');
+    }
+
+    it('default', function() {
+        const plugin = new CssoWebpackPlugin();
+        testDefaultOptions(plugin);
+        testDefaultFilter(plugin);
+    });
+
+    it('with options', function() {
+        const options = { test: 1 };
+        const plugin = new CssoWebpackPlugin(options);
+        assert.equal(plugin.options, options, 'single argument with options');
+        testDefaultFilter(plugin);
+    });
+
+    it('with regexp filter', function() {
+        const plugin = new CssoWebpackPlugin(/^text/gi);
+
+        testDefaultOptions(plugin);
+        assert.equal(plugin.filter('text-file.pcss'), true, 'text-file.pcss should be true');
+        assert.equal(plugin.filter('files.js'), false, 'files.js should be false');
+        assert.equal(plugin.filter('/.css/text'), false, '/.css/text should be false');
+
+        assert.doesNotThrow(
+            function() { new CssoWebpackPlugin({}, /^text/gi); },
+            'second argument should be approved'
+        );
+    });
+
+    it('with function filter', function() {
+        const filter = function() { return true; };
+
+        const oneArgPlugin = new CssoWebpackPlugin(filter);
+        testDefaultOptions(oneArgPlugin);
+        assert.equal(oneArgPlugin.filter, filter, 'single `filter` should be set to this.filter');
+
+        const twoArgPlugin = new CssoWebpackPlugin({}, filter);
+        assert.equal(twoArgPlugin.filter, filter, 'second argument `filter` should be set to this.filter');
+    });
+
+    it('unexpected type for filter', function() {
+        const expectedMessage = 'Error: filter should be one of these types: function, regexp, undefined';
+
+        function isExpectedError(err) {
+            return (err instanceof Error) && err.toString() === expectedMessage;
+        }
+
+        function createPlugin() {
+            new CssoWebpackPlugin({}, 'some text');
+        }
+
+        assert.throws(createPlugin, isExpectedError, 'throw error rise unexpected type');
+    });
+});


### PR DESCRIPTION
Pull Request improves:

* add exception for not expected type
* unit tests for plugin `constructor`