### PR TITLE
Generate a normal `.css` and a `.min.css` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ new CssoWebpackPlugin([options: CssoOptions], [filter: function | RegExp])
 
 Arguments:
 * `options` — [csso options](https://github.com/css/csso#minifysource-options).
+* `options.pluginOutputPostfix` — *function(file)* or *string postfix*, if passed, plugin will create two assets vanilla and compressed.
+   Example:
+   ```javascript
+   {
+       plugins: [
+           new ExtractTextPlugin('test.css'),
+           new CssoWebpackPlugin({ pluginOutputPostfix: 'min' })
+           /* Generated:
+               test.css — uncompressed file
+               test.min.css — minimized with csso file
+           */
+       ]
+   }
+   ```
 * `filter` — Detect should be file processed. Defaults: *to ends with `.css`*.
 
 ## Flow support

--- a/test/filter.js
+++ b/test/filter.js
@@ -21,7 +21,8 @@ describe('Constructor', function() {
     it('with options', function() {
         const options = { test: 1 };
         const plugin = new CssoWebpackPlugin(options);
-        assert.equal(plugin.options, options, 'single argument with options');
+        assert.deepEqual(plugin.options, { test: 1 }, 'single argument with options');
+        assert.deepEqual(options, { test: 1 }, 'single argument with options immutable');
         testDefaultFilter(plugin);
     });
 

--- a/test/integrations.js
+++ b/test/integrations.js
@@ -39,16 +39,33 @@ describe('Integrations with webpack 2', function() {
                     if (err) return reject(err);
                     if (stats.hasErrors()) return reject(new Error(stats.toString()));
 
-                    const actual = fs.readFileSync(join(outputDirectory, 'test.css'), 'utf-8');
-                    const expected = fs.readFileSync(join(testDirectory, 'expected.css'), 'utf-8')
-                        .replace(/\n$/g, '')
-                        .replace(/%%unit-hash%%/g, stats.hash);
+                    const expectedCssExt = 'expected.css';
 
-                    assert.equal(actual, expected,
-                        'Output ' + testCase + '/test.css file isn\'t equals ' + testCase + '/expected.css'
-                    );
+                    fs.readdir(testDirectory, function(err, files) {
+                        if (err) return reject(err);
 
-                    resolve();
+                        files = files.filter(name => name.endsWith(expectedCssExt));
+
+                        assert.ok(files.length > 0, 'Integration test should be with css file');
+
+                        files.forEach(name => {
+                            const prefix = name.substring(0, name.length - expectedCssExt.length) || '';
+                            const actualName = 'test.' + prefix + 'css';
+
+                            const actual = fs.readFileSync(join(outputDirectory, actualName), 'utf-8')
+                                .replace(/\n$/g, '');
+
+                            const expected = fs.readFileSync(join(testDirectory, name), 'utf-8')
+                                .replace(/\n$/g, '')
+                                .replace(/%%unit-hash%%/g, stats.hash);
+
+                            assert.equal(actual, expected,
+                                'Output ' + testCase + ' — ' + name + ' file isn\'t equals ${actualName}'
+                            );
+                        });
+
+                        resolve();
+                    });
                 });
             });
         });

--- a/test/integrations/plugin-output-postfix/expected.css
+++ b/test/integrations/plugin-output-postfix/expected.css
@@ -1,0 +1,3 @@
+.local-a.c .d { color: #fff; }
+.c .d { color: white; }
+.local-c .local-d { color: #ffffff; }

--- a/test/integrations/plugin-output-postfix/index.css
+++ b/test/integrations/plugin-output-postfix/index.css
@@ -1,0 +1,3 @@
+.a:global(.c .d) { color: #fff; }
+:global(.c .d) { color: white; }
+.c .d { color: #ffffff; }

--- a/test/integrations/plugin-output-postfix/index.js
+++ b/test/integrations/plugin-output-postfix/index.js
@@ -1,0 +1,1 @@
+require('./index.css');

--- a/test/integrations/plugin-output-postfix/min.expected.css
+++ b/test/integrations/plugin-output-postfix/min.expected.css
@@ -1,0 +1,1 @@
+.c .d,.local-a.c .d,.local-c .local-d{color:#fff}

--- a/test/integrations/plugin-output-postfix/webpack.config.js
+++ b/test/integrations/plugin-output-postfix/webpack.config.js
@@ -1,0 +1,9 @@
+const CssoWebpackPlugin = require('../../../lib').default;
+
+module.exports = {
+    plugins: [
+        new CssoWebpackPlugin({
+            pluginOutputPostfix: 'min'
+        }),
+    ]
+};


### PR DESCRIPTION
Resolve:
https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/637
https://github.com/css/csso/issues/353

Create new option `pluginOutputPostfix` for generate a normal css and a .min.css file:

```javascript
   {
       plugins: [
           new ExtractTextPlugin('test.css'),
           new CssoWebpackPlugin({ pluginOutputPostfix: 'min' })
           /* Generated:
               test.css — normal css file
               test.min.css — minimized with csso file
           */
       ]
   }
```
or


```javascript
   {
       plugins: [
           new ExtractTextPlugin('test.css'),
           new CssoWebpackPlugin({
               pluginOutputPostfix: file => 'min/' + file
           })
           /* Generated:
               test.css — normal css file
               min/test.css — minimized with csso file
           */
       ]
   }
```