### PR TITLE
Up to csso@^4 (release 2.0)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,19 +1,11 @@
 {
     "presets": [
-        [ "env", {
+        [ "@babel/preset-env", {
             "targets": {
-                "node": "0.10"
+                "node": "8"
             },
             "loose": true,
-            "useBuiltIns": true
+            "useBuiltIns": "entry"
         } ]
-    ],
-    "plugins": [
-        [
-            "transform-object-rest-spread",
-            {
-                "useBuiltIns": true
-            }
-        ]
     ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@ dist: trusty
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
+  - "8.0.0"
   - "8"
   - "9"
   - "10"
   - "11"
   - "12"
+  - "13"
   - "node"
 
 script: npm test

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ node_modules/csso-webpack-plugin/lib/index.js.flow
 ```
 
 ## Acknowledgements
-[![Develop By](https://img.shields.io/badge/develop%20by-zoobestik-blue.svg?style=flat)](https://ru.linkedin.com/in/kbchernenko) [![Develop By](https://img.shields.io/badge/designed%20by-@egorii-yellow.svg?style=flat)](https://www.linkedin.com/in/%D0%B5%D0%B3%D0%BE%D1%80-%D0%B0%D0%BB%D0%B5%D0%BA%D1%81%D0%B5%D0%B5%D0%B2-968a1265/) [![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![Develop By](https://img.shields.io/badge/develop%20by-zoobestik-blue.svg?style=flat)](https://ru.linkedin.com/in/kbchernenko) [![Logo By](https://img.shields.io/badge/logo%20by-@egorii-yellow.svg?style=flat)](https://www.linkedin.com/in/%D0%B5%D0%B3%D0%BE%D1%80-%D0%B0%D0%BB%D0%B5%D0%BA%D1%81%D0%B5%D0%B5%D0%B2-968a1265/) [![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
 [npm]: https://img.shields.io/npm/v/csso-webpack-plugin.svg
 [npm-url]: https://npmjs.com/package/csso-webpack-plugin

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@
 npm i -D csso-webpack-plugin
 ```
 
+For **`node` < 8.0.0** use [1.x](https://github.com/zoobestik/csso-webpack-plugin/tree/v1) version with `csso@^3`:
+```bash
+npm i -D csso-webpack-plugin@1
+```
+
 ## Usage
 Plugin good to use in pair with [ExtractTextPlugin](https://github.com/webpack-contrib/extract-text-webpack-plugin) or [MiniCssExtractPlugin](https://github.com/webpack-contrib/mini-css-extract-plugin).
 ```js
@@ -29,7 +34,10 @@ const CssoWebpackPlugin = require('csso-webpack-plugin').default;
 module.exports = {
   module: { /* ... */ },
   plugins: [
-    new ExtractTextPlugin('[name].css'),
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+      chunkFilename: "[id].css"
+    }),
     new CssoWebpackPlugin(),
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "./lib/index",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "licenses": [
     {
@@ -45,24 +45,23 @@
   ],
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "async": "^2.5.0",
-    "csso": "^3.4.0",
-    "source-map": "^0.6.1",
+    "csso": "^4.0.2",
+    "source-map": "^0.7.3",
     "webpack-sources": "^1.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
+    "@babel/cli": "^7.7.5",
+    "@babel/core": "^7.7.5",
+    "@babel/preset-env": "^7.7.6",
     "babel-eslint": "^10.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
     "css-loader": "^0.28.5",
-    "eslint": "^5.16.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^6.7.2",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.7.0",
     "extract-text-webpack-plugin": "^2.1.0",
-    "mocha": "^5.0.0",
+    "mocha": "^6.2.2",
     "pre-commit": "^1.2.2",
-    "rimraf": "^2.6.1",
+    "rimraf": "^3.0.0",
     "webpack": "^2.3.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import csso from 'csso';
-import async from 'async';
 import RawSource from 'webpack-sources/lib/RawSource';
 import SourceMapSource from 'webpack-sources/lib/SourceMapSource';
 import { SourceMapConsumer } from 'source-map';
@@ -12,12 +11,9 @@ const isFilterType = inst => typeof inst === 'function' || inst instanceof RegEx
 const getOutputAssetFilename = postfix => file => {
     const parsed = path.parse(file);
     parsed.ext = `.${postfix}${parsed.ext}`;
-    /* `base` for node <= 4 version required:
-     *   https://travis-ci.org/zoobestik/csso-webpack-plugin/jobs/296380161#L525 */
     parsed.base = `${parsed.name}${parsed.ext}`;
     return path.format(parsed);
 };
-
 
 /*
     New webpack 4 API,
@@ -25,13 +21,11 @@ const getOutputAssetFilename = postfix => file => {
  */
 const unCamelCase = str => str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
 
-const pluginCompatibility = (caller, hook, cb) => {
-    if (caller.hooks) {
-        caller.hooks[hook].tap('csso-webpack-plugin', cb);
-    } else {
-        caller.plugin(unCamelCase(hook), cb);
-    }
-};
+const pluginCompatibility = (caller, hook, tapAction, cb) => (
+    caller.hooks
+        ? caller.hooks[hook][tapAction]('csso-webpack-plugin', cb)
+        : caller.plugin(unCamelCase(hook), cb)
+);
 
 export default class CssoWebpackPlugin {
     constructor(opts, filter) {
@@ -68,16 +62,15 @@ export default class CssoWebpackPlugin {
     }
 
     apply(compiler) {
-        pluginCompatibility(compiler, 'compilation', compilation => {
+        pluginCompatibility(compiler, 'compilation', 'tap', compilation => {
             const options = this.options;
+            const { pluginOutputPostfix } = this;
 
-            pluginCompatibility(compilation, 'optimizeChunkAssets', (chunks, done) => {
-                async.forEach(chunks, (chunk, chunked) => {
-                    async.forEach(chunk.files, (file, callback) => {
+            const doChunks = async chunks => Promise.all(
+                chunks.map(chunk => Promise.all(
+                    chunk.files.map(async file => {
                         try {
-                            if (!this.filter(file)) {
-                                return callback();
-                            }
+                            if (!this.filter(file)) { return; }
 
                             let source;
                             let sourceMap;
@@ -106,8 +99,8 @@ export default class CssoWebpackPlugin {
 
                             let fileOutput = file;
 
-                            if (this.pluginOutputPostfix) {
-                                fileOutput = this.pluginOutputPostfix(file);
+                            if (pluginOutputPostfix) {
+                                fileOutput = pluginOutputPostfix(file);
                             }
 
                             let { css, map } = csso.minify(source, { // eslint-disable-line prefer-const
@@ -117,7 +110,8 @@ export default class CssoWebpackPlugin {
                             });
 
                             if (map && sourceMap) {
-                                map.applySourceMap(new SourceMapConsumer(sourceMap), fileOutput);
+                                const consumerMap = await new SourceMapConsumer(sourceMap);
+                                map.applySourceMap(consumerMap, fileOutput);
                             }
 
                             if (!map) {
@@ -128,22 +122,25 @@ export default class CssoWebpackPlugin {
                                 ? new SourceMapSource(css, fileOutput, map.toJSON ? map.toJSON() : map)
                                 : new RawSource(css);
                         } catch (err) {
-                            let error = err;
                             const prefix = `${file} from CssoWebpackPlugin\n`;
                             const { message, parseError, stack } = err;
+                            let error = `${message} ${stack}`;
 
                             if (parseError) {
                                 error = `${message} [${file}:${parseError.line}:${parseError.column}]`;
-                            } else {
-                                error = `${message} ${stack}`;
                             }
 
                             compilation.errors.push(new Error(`${prefix}${error}`));
                         }
+                    }),
+                )),
+            );
 
-                        return callback();
-                    }, chunked);
-                }, done);
+            pluginCompatibility(compilation, 'optimizeChunkAssets', 'tapAsync', (chunks, done) => {
+                doChunks(chunks)
+                    /*  it's important not to pass any args inside `done`
+                        NOT: .then(done), ONLY: .then(() => done()) */
+                    .then(() => done());
             });
         });
     }


### PR DESCRIPTION
Feature list:

- [x] Update for [CSSO 4](https://github.com/css/csso/releases/tag/v4.0.0)
- [x] Drop maintenance for **NODE < 8.0.0** (see `csso v4` release notes, it's incompatible)

Chores:
 * use native  `async/await` instead [async](https://www.npmjs.com/package/async)
 * moved to [`source-map`](https://github.com/mozilla/source-map/blob/master/CHANGELOG.md#070) with support WEBAssembly
 * Up-to-date unsupported dev dependencies